### PR TITLE
Removing blog footer link

### DIFF
--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -6,7 +6,6 @@
 			title: 'Ressources',
 			links: [
 				{ name: 'Documentation', href: 'https://docs.papillon.bzh' },
-				{ name: 'Blog', href: 'https://blog.papillon.bzh' },
 				{
 					name: 'Confidentialité',
 					href: 'https://docs.papillon.bzh/legal/privacy'


### PR DESCRIPTION
Because of the link to blog.papillon.bzh not going anywhere now